### PR TITLE
OMBU-590 add post-excerpt class links to accessibility code

### DIFF
--- a/lib/jekyll-external-link-accessibility.rb
+++ b/lib/jekyll-external-link-accessibility.rb
@@ -6,7 +6,7 @@ module Jekyll
     def self.modify_links(page)
       config = page.site.config
       doc = Nokogiri::HTML5(page.output)
-      doc.css('.post-content a').each do |a|
+      doc.css('.post-content a, .post-excerpt a').each do |a|
         next if a['href'].nil? || a['href'].empty? || a['href'].start_with?('#') || a['data-no-external'] == 'true'
 
         if a['href'].start_with?('http') || a['href'].start_with?('/')

--- a/lib/jekyll-external-link-accessibility/hooks.rb
+++ b/lib/jekyll-external-link-accessibility/hooks.rb
@@ -4,3 +4,7 @@ require 'jekyll-external-link-accessibility'
 Jekyll::Hooks.register :posts, :post_render do |page|
   Jekyll::ExternalLinkAccessibility.modify_links(page)
 end
+
+Jekyll::Hooks.register :pages, :post_render do |page|
+  Jekyll::ExternalLinkAccessibility.modify_links(page)
+end


### PR DESCRIPTION
Following QA comment on internal ticket, this would also add accessibility to links generated from markdown text into the post-excerpt classes.

