### PR TITLE
OMBU-615 scape .scss and .json files from hook

### DIFF
--- a/lib/jekyll-external-link-accessibility/hooks.rb
+++ b/lib/jekyll-external-link-accessibility/hooks.rb
@@ -6,5 +6,6 @@ Jekyll::Hooks.register :posts, :post_render do |page|
 end
 
 Jekyll::Hooks.register :pages, :post_render do |page|
+  next if page.extname == '.scss' || page.extname == '.json'
   Jekyll::ExternalLinkAccessibility.modify_links(page)
 end


### PR DESCRIPTION
This PR adds scape for `.scss` and `.json` files from hook to change links.
The hooks registered under `Jekyll::Hooks.register :pages` is going beyond articles and affecting and changing how some files are being handled in the application.

