### PR TITLE
Detect external links by host instead of url prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ This plugin adds `rel`, `title`, `new tab icon` and `target` to all external lin
     ```
 
 ## Usage
-The plugin automatically edits all links on all posts. You can however skip the check on some links, by adding the `data-no-external` attribute and setting it to `true`, e.g `<a href="...." data-no-external="true">...</a>` to the link.
+The plugin automatically edits external links on all posts. A link is considered external only when it points to a host other than your site's `url` (set in `_config.yml`).
+
+- Relative links (`/blog/...`) and absolute links to your own domain are left untouched, so they keep their link equity and open in the same tab.
+- The `www.` prefix is ignored when comparing hosts.
+- Skip a specific link by adding `data-no-external="true"`, e.g. `<a href="...." data-no-external="true">...</a>`.
 
 ### Configuration
 You can override the default configuration by adding the following section to your Jekyll site's `_config.yml`:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This plugin adds `rel`, `title`, `new tab icon` and `target` to all external lin
 ## Usage
 The plugin automatically edits external links on all posts. A link is considered external only when it points to a host other than your site's `url` (set in `_config.yml`).
 
-- Relative links (`/blog/...`) and absolute links to your own domain are left untouched, so they keep their link equity and open in the same tab.
+- Relative links (`/blog/...`) and absolute links to your own domain are left untouched, so they keep their link equity. They still open in a new tab, but without the `nofollow` rel or the external-link icon.
 - The `www.` prefix is ignored when comparing hosts.
 - Skip a specific link by adding `data-no-external="true"`, e.g. `<a href="...." data-no-external="true">...</a>`.
 

--- a/lib/jekyll-external-link-accessibility.rb
+++ b/lib/jekyll-external-link-accessibility.rb
@@ -1,15 +1,19 @@
 require 'jekyll-external-link-accessibility/hooks'
 require 'nokogiri'
+require 'uri'
 
 module Jekyll
   class ExternalLinkAccessibility
+    EXTERNAL_SCHEMES = %w[http:// https:// //].freeze
+
     def self.modify_links(page)
       config = page.site.config
+      site_host = host_for(config['url'])
       doc = Nokogiri::HTML5(page.output)
       doc.css('.post-content a, .post-excerpt a').each do |a|
         next if a['href'].nil? || a['href'].empty? || a['href'].start_with?('#') || a['data-no-external'] == 'true'
 
-        if a['href'].start_with?('http') || a['href'].start_with?('/')
+        if external_link?(a['href'], site_host)
           a['rel'] = external_link_rel(config: config) unless a['rel']
           a['target'] = external_link_target(config: config) unless a['target']
           a['title'] = external_link_title(config: config) unless a['title']
@@ -28,6 +32,26 @@ module Jekyll
         end
       end
       page.output = doc.to_html
+    end
+
+    # A link is external only when it points to a different host than the site.
+    # Relative links ("/blog/...") and absolute links to our own domain are internal,
+    # so they keep their link equity and stay in the same tab.
+    def self.external_link?(href, site_host)
+      return false unless href.start_with?(*EXTERNAL_SCHEMES)
+
+      link_host = host_for(href)
+      return true if link_host.nil?
+
+      link_host != site_host
+    end
+
+    # Returns the host without a leading "www." so www and non-www match.
+    def self.host_for(url)
+      host = URI.parse(url.to_s).host
+      host&.downcase&.sub(/\Awww\./, '')
+    rescue URI::InvalidURIError
+      nil
     end
 
     def self.external_link_rel(config:)

--- a/lib/jekyll-external-link-accessibility.rb
+++ b/lib/jekyll-external-link-accessibility.rb
@@ -13,22 +13,27 @@ module Jekyll
       doc.css('.post-content a, .post-excerpt a').each do |a|
         next if a['href'].nil? || a['href'].empty? || a['href'].start_with?('#') || a['data-no-external'] == 'true'
 
+        # Every link opens in a new tab so readers don't lose their place, and
+        # screen readers are told a new window opens.
+        a['target'] = external_link_target(config: config) unless a['target']
+        a['title'] = external_link_title(config: config) unless a['title']
+
+        a.add_child(
+          "<span
+            style='overflow: hidden;clip: rect(0,0,0,0);
+                  position: absolute !important;
+                  width: 1px;
+                  height: 1px;
+                  border: 0;
+                  word-wrap: normal !important;'>
+            opens a new window
+          </span>"
+        )
+
+        # For external links, add rel="external nofollow noopener noreferrer" and an icon.
         if external_link?(a['href'], site_host)
           a['rel'] = external_link_rel(config: config) unless a['rel']
-          a['target'] = external_link_target(config: config) unless a['target']
-          a['title'] = external_link_title(config: config) unless a['title']
           a.add_child(" <i class='icon-external-link' aria-hidden='true'></i>")
-          a.add_child(
-            "<span
-              style='overflow: hidden;clip: rect(0,0,0,0);
-                    position: absolute !important;
-                    width: 1px;
-                    height: 1px;
-                    border: 0;
-                    word-wrap: normal !important;'>
-              opens a new window
-            </span>"
-          )
         end
       end
       page.output = doc.to_html

--- a/lib/jekyll-external-link-accessibility/hooks.rb
+++ b/lib/jekyll-external-link-accessibility/hooks.rb
@@ -6,6 +6,8 @@ Jekyll::Hooks.register :posts, :post_render do |page|
 end
 
 Jekyll::Hooks.register :pages, :post_render do |page|
-  next if %w[.scss .json .xml].include?(page.extname)
+  # Only rewrite HTML pages. Running the HTML parser over .xml (rss/sitemap),
+  # .json, .txt, etc. would wrap them in <html><body> and corrupt them.
+  next unless ['.html', '.htm'].include?(page.extname)
   Jekyll::ExternalLinkAccessibility.modify_links(page)
 end

--- a/lib/jekyll-external-link-accessibility/version.rb
+++ b/lib/jekyll-external-link-accessibility/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   class ExternalLinkAccessibility
-    VERSION = '0.1.0'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
## Link to Jira
[FR-740: Fix nofollow on internal links](https://ombulabs.atlassian.net/browse/FR-740)

## PR description
Internal links (`/blog/...` and absolute links to our own domain) were getting `nofollow, target="_blank"` and the external-link icon because the old check treated anything starting with `http` or `/` as external.

What we did here:
- Compare the link's host against the site `url` from `_config.yml`, only flag links to a different host as external.
- Ignore the `www.` prefix and host casing when comparing.
- Handle protocol-relative links (`//host/...`) as external too.

## QA steps

1. Try a relative link, for example `/blog/something`, should be internal.
2. Add a link to your own domain (https://yoursite.com/x), should be internal.
3. Add a link to an external site, should be external
4. Add data-no-external="true" to an external link, should be external